### PR TITLE
mobile-wrap-header

### DIFF
--- a/src/css/header.css
+++ b/src/css/header.css
@@ -107,6 +107,13 @@
 
 /* mobile menu*/
 
+/* add  menu-mobile-wrap*/
+.menu-mobile-wrap {
+  position: relative;
+  margin: 0 auto;
+  max-width: 375px;
+}
+
 .menu-mobile-logo {
   height: 50px;
   background-color: #fff;
@@ -186,7 +193,7 @@
 }
 .mobile-btn {
   display: flex;
- justify-content: center;
+  justify-content: center;
   border: none;
   background-color: transparent;
 }

--- a/src/partials/header.html
+++ b/src/partials/header.html
@@ -46,21 +46,24 @@
 
 <div class="menu-container-mobile js-menu-container" id="mobile-menu">
   <div class="menu-mobile-logo">
-    <ul class="menu-logo">
-      <li class="icon-header">
-        <a class="icon-vector" href="">
-          <svg width="16" height="16">
-            <use href="./img/icon.svg#icon-vector-1"></use>
-          </svg>
-          <p class="header-text">fresh harvest box</p>
-        </a>
-      </li>
-    </ul>
-    <button class="menu-toggle js-close-menu">
-      <svg width="24" height="24">
-        <use href="./img/icon.svg#icon-X"></use>
-      </svg>
-    </button>
+    <!-- add div menu-mobile-wrap -->
+    <div class="menu-mobile-wrap">
+      <ul class="menu-logo">
+        <li class="icon-header">
+          <a class="icon-vector" href="">
+            <svg width="16" height="16">
+              <use href="./img/icon.svg#icon-vector-1"></use>
+            </svg>
+            <p class="header-text">fresh harvest box</p>
+          </a>
+        </li>
+      </ul>
+      <button class="menu-toggle js-close-menu">
+        <svg width="24" height="24">
+          <use href="./img/icon.svg#icon-X"></use>
+        </svg>
+      </button>
+    </div>
   </div>
 
   <nav>


### PR DESCRIPTION
додана обгортка в хедер, що центрує лого і кнопку мобільного меню по розміру 375px, а не по вьюпорту, як було до цього